### PR TITLE
[desc-pyspark] Update the spark version to 3.0.0

### DIFF
--- a/jupyter-kernels/desc-pyspark/README.md
+++ b/jupyter-kernels/desc-pyspark/README.md
@@ -4,11 +4,12 @@ This kernel allows DESC members to use the desc-python kernel with PySpark at NE
 By default the kernel uses 4 threads. It has been generated using:
 https://github.com/astrolabsoftware/spark-kernel-nersc#apache-spark-kernel-for-desc-members-recommended
 
-The Apache Spark version in use is currently 2.3.2. This version is maintained by Julien Peloton at NERSC and it is not intended for running batch or interactive jobs. For that purpose see rather:
+The Apache Spark version in use is currently 3.0.0. This version is maintained by Julien Peloton at NERSC and it is not intended for running batch or interactive jobs. For that purpose see rather:
 https://github.com/LSSTDESC/desc-spark#working-at-nersc-batch-mode
 
 If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in2p3.fr).
 
 # Logbook
 
-- 12/11/2018: Initial release of the kernel.
+- 12/11/2018: Initial release of the kernel using Spark 2.4.4
+- 17/07/2020: Update Spark version to 3.0.0

--- a/jupyter-kernels/desc-pyspark/README.md
+++ b/jupyter-kernels/desc-pyspark/README.md
@@ -9,6 +9,24 @@ https://github.com/LSSTDESC/desc-spark#working-at-nersc-batch-mode
 
 If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in2p3.fr).
 
+## Using Pyarrow > 0.13
+
+By default, the current desc-python version uses `pyarrow==0.13` which is not compatible with Spark 3.0.0. While waiting for an upgrade of the package (see this discussion for example https://github.com/LSSTDESC/desc-help/issues/25), you will need to install yourself a higher version of pyarrow:
+
+```bash
+# this will install 0.17+
+pip install pyarrow --user --upgrade
+```
+
+and add it to the `DESCPYTHONPATH`:
+
+```bash
+# in your ~/.bashrc.ext for example
+DESCPYTHONPATH=$HOME/.local/lib/python3.7/site-packages:$DESCPYTHONPATH
+```
+
+Beware if you have other things installed here - there could be conflicts!
+
 # Logbook
 
 - 12/11/2018: Initial release of the kernel using Spark 2.4.0

--- a/jupyter-kernels/desc-pyspark/README.md
+++ b/jupyter-kernels/desc-pyspark/README.md
@@ -11,5 +11,5 @@ If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in
 
 # Logbook
 
-- 12/11/2018: Initial release of the kernel using Spark 2.4.4
+- 12/11/2018: Initial release of the kernel using Spark 2.4.0
 - 17/07/2020: Update Spark version to 3.0.0

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -15,6 +15,7 @@ export SPARK_LOCAL_DIRS="${SCRATCH}/sparktmp"
 
 # Path to LSST miniconda installation at NERSC
 LSSTCONDA="/global/common/software/lsst/common/miniconda"
+LSSTCONDABIN="${LSSTCONDA}/py3.7-4.7.12.1-v1/envs/desc/bin"
 
 # Since the default NERSC Apache Spark runs inside of Shifter, we use
 # a custom local version of it. This is maintained by me (Julien Peloton)
@@ -30,8 +31,8 @@ export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
 export DESCPYTHONPATH="${SPARKPATH}/python/lib/py4j-0.10.9-src.zip:${SPARKPATH}/python:${DESCPYTHONPATH}"
 
 # Should correspond to desc-python
-export PYSPARK_PYTHON="${LSSTCONDA}/current/bin/python"
-export PYSPARK_DRIVER_PYTHON="${LSSTCONDA}/current/bin/ipython3"
+export PYSPARK_PYTHON="${LSSTCONDABIN}/python"
+export PYSPARK_DRIVER_PYTHON="${LSSTCONDABIN}/ipython"
 
 export JAVA_HOME="/usr/lib64/jvm/java"
 

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -24,7 +24,7 @@ SPARKPATH="/global/homes/p/peloton/myspark/spark-3.0.0-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${SPARKPATH}"
-export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.4 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.4 --conf spark.driver.extraJavaOptions=-Dio.netty.tryReflectionSetAccessible=true --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
 export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
 
 # Make sure the version of py4j is correct.

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -19,22 +19,21 @@ LSSTCONDA="/global/common/software/lsst/common/miniconda"
 # Since the default NERSC Apache Spark runs inside of Shifter, we use
 # a custom local version of it. This is maintained by me (Julien Peloton)
 # at NERSC. If you encounter problems, let me know (peloton at lal.in2p3.fr)!
-SPARKPATH="/global/homes/p/peloton/myspark/spark-2.4.0-bin-hadoop2.7"
+SPARKPATH="/global/homes/p/peloton/myspark/spark-3.0.0-bin-hadoop2.7"
 
 # Here is the environment needed for Spark to run at NERSC.
 export SPARK_HOME="${SPARKPATH}"
-export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.7.2 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
+export PYSPARK_SUBMIT_ARGS="--master local[4] --driver-memory 8g --executor-memory 8g --packages com.github.astrolabsoftware:spark-fits_2.11:0.8.4 --conf spark.eventLog.enabled=true --conf spark.eventLog.dir=file://${SCRATCH}/spark/event_logs --conf spark.history.fs.logDirectory=file://${SCRATCH}/spark/event_logs pyspark-shell"
 export PYTHONSTARTUP="${SPARKPATH}/python/pyspark/shell.py"
 
 # Make sure the version of py4j is correct.
-export DESCPYTHONPATH="${SPARKPATH}/python/lib/py4j-0.10.7-src.zip:${SPARKPATH}/python:${DESCPYTHONPATH}"
+export DESCPYTHONPATH="${SPARKPATH}/python/lib/py4j-0.10.9-src.zip:${SPARKPATH}/python:${DESCPYTHONPATH}"
 
 # Should correspond to desc-python
 export PYSPARK_PYTHON="${LSSTCONDA}/current/bin/python"
 export PYSPARK_DRIVER_PYTHON="${LSSTCONDA}/current/bin/ipython3"
 
-# We use Java 8. Spark 2+ does not work with Java 7 and earlier versions.
-export JAVA_HOME="/opt/java/jdk1.8.0_51"
+export JAVA_HOME="/usr/lib64/jvm/java"
 
 # desc-python activation script
 source ${LSSTCONDA}/kernels/python.sh


### PR DESCRIPTION
This PR updates the `desc-pyspark` kernel by upgrading the Spark version to 3.0.0 (see #51).

The update has been tested successfully at NERSC.