### PR TITLE
[desc-pyspark] Change the activation script to python-dev

### DIFF
--- a/jupyter-kernels/desc-pyspark/README.md
+++ b/jupyter-kernels/desc-pyspark/README.md
@@ -9,25 +9,8 @@ https://github.com/LSSTDESC/desc-spark#working-at-nersc-batch-mode
 
 If you have trouble with this kernel, contact me (Julien Peloton, peloton@lal.in2p3.fr).
 
-## Using Pyarrow > 0.13
-
-By default, the current desc-python version uses `pyarrow==0.13` which is not compatible with Spark 3.0.0. While waiting for an upgrade of the package (see this discussion for example https://github.com/LSSTDESC/desc-help/issues/25), you will need to install yourself a higher version of pyarrow:
-
-```bash
-# this will install 0.17+
-pip install pyarrow --user --upgrade
-```
-
-and add it to the `DESCPYTHONPATH`:
-
-```bash
-# in your ~/.bashrc.ext for example
-DESCPYTHONPATH=$HOME/.local/lib/python3.7/site-packages:$DESCPYTHONPATH
-```
-
-Beware if you have other things installed here - there could be conflicts!
-
 # Logbook
 
 - 12/11/2018: Initial release of the kernel using Spark 2.4.0
-- 17/07/2020: Update Spark version to 3.0.0
+- 17/07/2020: Update Spark version to 3.0.0 (see #52)
+- 21/07/2020: Use `desc-python-dev` as backend (see #53)

--- a/jupyter-kernels/desc-pyspark/desc-pyspark.sh
+++ b/jupyter-kernels/desc-pyspark/desc-pyspark.sh
@@ -15,7 +15,7 @@ export SPARK_LOCAL_DIRS="${SCRATCH}/sparktmp"
 
 # Path to LSST miniconda installation at NERSC
 LSSTCONDA="/global/common/software/lsst/common/miniconda"
-LSSTCONDABIN="${LSSTCONDA}/py3.7-4.7.12.1-v1/envs/desc/bin"
+LSSTCONDABIN="${LSSTCONDA}/dev/envs/desc/bin"
 
 # Since the default NERSC Apache Spark runs inside of Shifter, we use
 # a custom local version of it. This is maintained by me (Julien Peloton)
@@ -37,4 +37,4 @@ export PYSPARK_DRIVER_PYTHON="${LSSTCONDABIN}/ipython"
 export JAVA_HOME="/usr/lib64/jvm/java"
 
 # desc-python activation script
-source ${LSSTCONDA}/kernels/python.sh
+source ${LSSTCONDA}/kernels/python-dev.sh


### PR DESCRIPTION
This PR changes the activation script from `python.sh` to `python-dev.sh` for the `desc-pyspark` kernel. 

Following #53, we noticed that using the `desc-python-dev` environment was solving the problem related to `pyarrow` from`desc-python` (0.15.1 vs 0.17.1). I do not know yet the cause of the problem.