### PR TITLE
Use mamba to handle creation of desc env

### DIFF
--- a/conda/install-desc.sh
+++ b/conda/install-desc.sh
@@ -22,9 +22,11 @@ which python
 #export PATH=$1/bin:$PATH
 source $1/etc/profile.d/conda.sh
 conda activate base
+conda install -c conda-forge -y mamba
 which python
-
-conda env create -n desc -f $2
+which conda
+mamba env create -n desc -f $2
+conda env list
 
 #source $1/etc/profile.d/conda.sh
 conda activate desc


### PR DESCRIPTION
mamba is running much faster than attempting a `conda install`