### PR TITLE
Update setup of desc-python:bleed kernel

### DIFF
--- a/jupyter-kernels/setup/setup_bleed_python.sh
+++ b/jupyter-kernels/setup/setup_bleed_python.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export DESC_INST_DIR=/usr/local/
+export DESC_INST_DIR=/opt/desc
 export DESC_PYTHON_VER=py
 
 export OMP_NUM_THREADS=1
@@ -16,7 +16,6 @@ export DESC_GCR_SITE='nersc'
 
 source $DESC_INST_DIR/$DESC_PYTHON_VER/etc/profile.d/conda.sh
 conda activate base
-conda activate desc
 if [ -n "$DESCUSERENV" ]; then
    conda activate $DESCUSERENV
 fi


### PR DESCRIPTION
Addressing #114 to modify setup of desc-python:bleed kernel to use new installation dir (/opt/desc/py) and base environment