### PR TITLE
add support for PYTHONUSERBASE setup using DESCPYTHONUSERBASE

### DIFF
--- a/jupyter-kernels/setup/setup_bleed_python.sh
+++ b/jupyter-kernels/setup/setup_bleed_python.sh
@@ -20,6 +20,20 @@ if [ -n "$DESCUSERENV" ]; then
    conda activate $DESCUSERENV
 fi
 
+python_ver_major=$(python -c 'import sys; print(sys.version_info.major)')
+python_ver_minor=$(python -c 'import sys; print(sys.version_info.minor)')
+export DESCPYTHONVER="python$python_ver_major.$python_ver_minor"
+
+export PYTHONPATH=$PYTHONPATH:$LSST_INST_DIR/$LSST_PYTHON_VER
+
+if [ -n "$DESCPYTHONBLEEDUSERBASE" ]; then
+    export PYTHONUSERBASE=$DESCPYTHONBLEEDUSERBASE
+    unset PYTHONUSERSITE
+    export PYTHONPATH="$PYTHONUSERBASE/lib/$DESCPYTHONVER/site-packages:$PYTHONPATH"
+    echo "using DESCPYTHONBLEEDUSERBASE: $DESCPYTHONBLEEDUSERBASE"
+fi
+
+
 export HDF5_USE_FILE_LOCKING=FALSE
 
 if [ $# -gt 0 ] ; then

--- a/jupyter-kernels/setup/setup_current_python.sh
+++ b/jupyter-kernels/setup/setup_current_python.sh
@@ -31,11 +31,24 @@ export PYTHONNOUSERSITE=' '
 
 export DESC_GCR_SITE='nersc'
 
+
+#if [ -n "$DESCPYTHONUSERBASE" ]; then
+#    export PYTHONUSERBASE=$DESCPYTHONUSERBASE	
+#    unset PYTHONUSERSITE
+#    echo "using DESCPYTHONUSERBASE: $DESCPYTHONUSERBASE"
+#fi
+
 source $LSST_INST_DIR/$LSST_PYTHON_VER/etc/profile.d/conda.sh
 conda activate base
 if [ -n "$DESCUSERENV" ]; then
    conda activate $DESCUSERENV
 fi
+
+
+# Set this after conda environment is setup
+python_ver_major=$(python -c 'import sys; print(sys.version_info.major)')
+python_ver_minor=$(python -c 'import sys; print(sys.version_info.minor)')
+export DESCPYTHONVER="python$python_ver_major.$python_ver_minor"
 
 if [ -n "$DESCPYTHONPATH" ]; then
     export PYTHONPATH=$PYTHONPATH:"$DESCPYTHONPATH"
@@ -43,6 +56,13 @@ if [ -n "$DESCPYTHONPATH" ]; then
 fi 
 
 export PYTHONPATH=$PYTHONPATH:$LSST_INST_DIR/$LSST_PYTHON_VER
+
+if [ -n "$DESCPYTHONUSERBASE" ]; then
+    export PYTHONUSERBASE=$DESCPYTHONUSERBASE	
+    unset PYTHONUSERSITE
+    export PYTHONPATH="$PYTHONUSERBASE/lib/$DESCPYTHONVER/site-packages:$PYTHONPATH"
+    echo "using DESCPYTHONUSERBASE: $DESCPYTHONUSERBASE"
+fi
 
 OUTPUTPY="$(which python)"
 echo Now using "${OUTPUTPY}"

--- a/jupyter-kernels/setup/stack-weekly.sh
+++ b/jupyter-kernels/setup/stack-weekly.sh
@@ -26,6 +26,19 @@ if [ -n "$DESCSTACKUSERENV" ]; then
     echo "Wondering Why? DESCSTACKUSERENV is likely set in your $HOME/.basrhc, $HOME/.bashrc.ext, or similar config script"
 fi
 
+python_ver_major=$(python -c 'import sys; print(sys.version_info.major)')
+python_ver_minor=$(python -c 'import sys; print(sys.version_info.minor)')
+export DESCPYTHONVER="python$python_ver_major.$python_ver_minor"
+
+export PYTHONPATH=$PYTHONPATH:$LSST_INST_DIR/$LSST_PYTHON_VER
+
+if [ -n "$DESCSTACKUSERBASE" ]; then
+    export PYTHONUSERBASE=$DESCSTACKUSERBASE
+    unset PYTHONUSERSITE
+    export PYTHONPATH="$PYTHONUSERBASE/lib/$DESCPYTHONVER/site-packages:$PYTHONPATH"
+    echo "using DESCPYTHONUSERBASE: $DESCSTACKUSERBASE"
+fi
+
 
 export PYTHONPATH=".:$PYTHONPATH"
 


### PR DESCRIPTION
Fixes #144 
Handles 3 new optional environment variables
DESCPYTHONUSERBASE  used in desc-python
DESCPYTHONBLEEDUSERBASE  used by desc-python-bleed
DESCSTACKUSERBASE  used by desc-stack-weekly and desc-stack-weekly-latest
If set, these will point to the directory where `pip install --user` installs will store the resulting bin and lib.
The setup scripts of each desc conda environment will handle setting PYTHONPATH appropriately based on the version of python in use.
